### PR TITLE
Add a panel that shows a list of all known wallets, allowing quick access to balance information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Added
 
 - A panel that shows a list of all known smart contracts, allowing quick access to contract metadata
+- A panel that shows a list of all known wallets, allowing quick access to balance information
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -278,7 +278,7 @@
         },
         {
           "command": "neo3-visual-devtracker.neo.walletCreate",
-          "when": "view == neo3-visual-devtracker.views.blockchains"
+          "when": "view == neo3-visual-devtracker.views.wallets"
         }
       ]
     },
@@ -287,6 +287,10 @@
         {
           "id": "neo3-visual-devtracker.views.blockchains",
           "name": "Blockchains"
+        },
+        {
+          "id": "neo3-visual-devtracker.views.wallets",
+          "name": "Wallets"
         },
         {
           "id": "neo3-visual-devtracker.views.contracts",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "onCommand:neo3-visual-devtracker.neo.walletCreate",
     "onCommand:neo3-visual-devtracker.tracker.openContract",
     "onCommand:neo3-visual-devtracker.tracker.openTracker",
+    "onCommand:neo3-visual-devtracker.tracker.openWallet",
     "onCustomEditor:neo3-visual-devtracker.express.neo-invoke-json",
     "onView:neo3-visual-devtracker.views.blockchains",
     "onView:neo3-visual-devtracker.views.quickStart",
@@ -167,6 +168,11 @@
           "light": "resources/light/open.svg",
           "dark": "resources/dark/open.svg"
         }
+      },
+      {
+        "command": "neo3-visual-devtracker.tracker.openWallet",
+        "title": "Show wallet",
+        "category": "Neo N3 Visual DevTracker"
       },
       {
         "command": "neo3-visual-devtracker.connect",

--- a/src/extension/autoComplete.ts
+++ b/src/extension/autoComplete.ts
@@ -180,11 +180,14 @@ export default class AutoComplete {
 
     const wallets = [...this.walletDetector.wallets];
     for (const wallet of wallets) {
-      for (const address of wallet.accounts.map((_) => _.address)) {
-        newData.addressNames[address] = newData.addressNames[address] || [];
-        newData.addressNames[address].push(wallet.path);
-        newData.addressNames[address] = dedupeAndSort(
-          newData.addressNames[address]
+      for (const account of wallet.accounts) {
+        newData.addressNames[account.address] =
+          newData.addressNames[account.address] || [];
+        newData.addressNames[account.address].push(
+          account.label || wallet.path
+        );
+        newData.addressNames[account.address] = dedupeAndSort(
+          newData.addressNames[account.address]
         );
       }
     }

--- a/src/extension/commands/commandArguments.ts
+++ b/src/extension/commands/commandArguments.ts
@@ -1,4 +1,4 @@
-import BlockchainIdentifier from "./blockchainIdentifier";
+import BlockchainIdentifier from "../blockchainIdentifier";
 
 //
 // Represents all possible arguments to any command explosed by
@@ -16,6 +16,7 @@ import BlockchainIdentifier from "./blockchainIdentifier";
 //   );
 //
 type CommandArguments = {
+  address?: string;
   amount?: number;
   asset?: string;
   blockchainIdentifier?: BlockchainIdentifier;
@@ -28,6 +29,9 @@ type CommandArguments = {
 
 async function sanitizeCommandArguments(input: any): Promise<CommandArguments> {
   return {
+    address: input.address
+      ? `${input.address}`.replace(/[^a-z0-9]/gi, "")
+      : undefined,
     amount: parseFloat(input.amount) || undefined,
     asset: input.asset
       ? `${input.asset}`.replace(/[^a-z0-9]/gi, "")

--- a/src/extension/commands/neoCommands.ts
+++ b/src/extension/commands/neoCommands.ts
@@ -6,7 +6,7 @@ import * as vscode from "vscode";
 
 import ActiveConnection from "../activeConnection";
 import BlockchainsTreeDataProvider from "../vscodeProviders/blockchainsTreeDataProvider";
-import { CommandArguments } from "../commandArguments";
+import { CommandArguments } from "./commandArguments";
 import ContractDetector from "../fileDetectors/contractDetector";
 import IoHelpers from "../util/ioHelpers";
 import JSONC from "../util/JSONC";

--- a/src/extension/commands/neoExpressCommands.ts
+++ b/src/extension/commands/neoExpressCommands.ts
@@ -6,7 +6,7 @@ import BlockchainIdentifier from "../blockchainIdentifier";
 import BlockchainMonitorPool from "../blockchainMonitor/blockchainMonitorPool";
 import BlockchainsTreeDataProvider from "../vscodeProviders/blockchainsTreeDataProvider";
 import CheckpointDetector from "../fileDetectors/checkpointDetector";
-import { CommandArguments } from "../commandArguments";
+import { CommandArguments } from "./commandArguments";
 import ContractDetector from "../fileDetectors/contractDetector";
 import IoHelpers from "../util/ioHelpers";
 import NeoExpress from "../neoExpress/neoExpress";

--- a/src/extension/commands/trackerCommands.ts
+++ b/src/extension/commands/trackerCommands.ts
@@ -7,6 +7,7 @@ import { CommandArguments } from "./commandArguments";
 import ContractPanelController from "../panelControllers/contractPanelController";
 import IoHelpers from "../util/ioHelpers";
 import TrackerPanelController from "../panelControllers/trackerPanelController";
+import WalletPanelController from "../panelControllers/walletPanelController";
 
 export default class TrackerCommands {
   static async openContract(
@@ -14,9 +15,9 @@ export default class TrackerCommands {
     autoComplete: AutoComplete,
     commandArguments: CommandArguments
   ) {
-    const autoCompleteData = autoComplete.data;
     let hash = commandArguments.hash;
     if (!hash) {
+      const autoCompleteData = autoComplete.data;
       if (!!Object.keys(autoCompleteData.contractNames).length) {
         const selection = await IoHelpers.multipleChoice(
           "Select a contract",
@@ -59,6 +60,35 @@ export default class TrackerCommands {
         autoComplete,
         blockchainMonitorPool
       );
+    }
+  }
+
+  static async openWallet(
+    context: vscode.ExtensionContext,
+    autoComplete: AutoComplete,
+    commandArguments: CommandArguments
+  ) {
+    let address = commandArguments.address;
+    if (!address) {
+      const autoCompleteData = autoComplete.data;
+      if (!!Object.keys(autoCompleteData.addressNames).length) {
+        const selection = await IoHelpers.multipleChoice(
+          "Select a wallet",
+          ...Object.keys(autoCompleteData.addressNames).map(
+            (_) => `${_} - ${autoCompleteData.addressNames[_].join(", ")}`
+          )
+        );
+        if (selection) {
+          address = selection.split(" ")[0];
+        }
+      } else {
+        vscode.window.showInformationMessage(
+          "No wallets found in current workspace"
+        );
+      }
+    }
+    if (address) {
+      new WalletPanelController(context, address, autoComplete);
     }
   }
 }

--- a/src/extension/commands/trackerCommands.ts
+++ b/src/extension/commands/trackerCommands.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 
+import ActiveConnection from "../activeConnection";
 import AutoComplete from "../autoComplete";
 import BlockchainMonitorPool from "../blockchainMonitor/blockchainMonitorPool";
 import BlockchainsTreeDataProvider from "../vscodeProviders/blockchainsTreeDataProvider";
@@ -66,7 +67,8 @@ export default class TrackerCommands {
   static async openWallet(
     context: vscode.ExtensionContext,
     autoComplete: AutoComplete,
-    commandArguments: CommandArguments
+    commandArguments: CommandArguments,
+    activeConnection: ActiveConnection
   ) {
     let address = commandArguments.address;
     if (!address) {
@@ -88,7 +90,12 @@ export default class TrackerCommands {
       }
     }
     if (address) {
-      new WalletPanelController(context, address, autoComplete);
+      new WalletPanelController(
+        context,
+        address,
+        autoComplete,
+        activeConnection
+      );
     }
   }
 }

--- a/src/extension/commands/trackerCommands.ts
+++ b/src/extension/commands/trackerCommands.ts
@@ -3,7 +3,7 @@ import * as vscode from "vscode";
 import AutoComplete from "../autoComplete";
 import BlockchainMonitorPool from "../blockchainMonitor/blockchainMonitorPool";
 import BlockchainsTreeDataProvider from "../vscodeProviders/blockchainsTreeDataProvider";
-import { CommandArguments } from "../commandArguments";
+import { CommandArguments } from "./commandArguments";
 import ContractPanelController from "../panelControllers/contractPanelController";
 import IoHelpers from "../util/ioHelpers";
 import TrackerPanelController from "../panelControllers/trackerPanelController";

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -6,7 +6,10 @@ import BlockchainIdentifier from "./blockchainIdentifier";
 import BlockchainMonitorPool from "./blockchainMonitor/blockchainMonitorPool";
 import BlockchainsTreeDataProvider from "./vscodeProviders/blockchainsTreeDataProvider";
 import CheckpointDetector from "./fileDetectors/checkpointDetector";
-import { CommandArguments, sanitizeCommandArguments } from "./commandArguments";
+import {
+  CommandArguments,
+  sanitizeCommandArguments,
+} from "./commands/commandArguments";
 import ContractDetector from "./fileDetectors/contractDetector";
 import ContractsTreeDataProvider from "./vscodeProviders/contractsTreeDataProvider";
 import Log from "../shared/log";
@@ -21,6 +24,7 @@ import ServerListDetector from "./fileDetectors/serverListDetector";
 import Templates from "./templates/templates";
 import TrackerCommands from "./commands/trackerCommands";
 import WalletDetector from "./fileDetectors/walletDetector";
+import WalletsTreeDataProvider from "./vscodeProviders/walletsTreeDataProvider";
 
 const LOG_PREFIX = "index";
 
@@ -64,6 +68,11 @@ export async function activate(context: vscode.ExtensionContext) {
   const activeConnection = new ActiveConnection(
     blockchainsTreeDataProvider,
     blockchainMonitorPool
+  );
+  const walletsTreeDataProvider = new WalletsTreeDataProvider(
+    context.extensionPath,
+    activeConnection,
+    walletDetector
   );
   const contractDetector = new ContractDetector(activeConnection);
   const neoExpressInstanceManager = new NeoExpressInstanceManager(
@@ -110,6 +119,13 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.window.registerTreeDataProvider(
       "neo3-visual-devtracker.views.contracts",
       contractsTreeDataProvider
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.window.registerTreeDataProvider(
+      "neo3-visual-devtracker.views.wallets",
+      walletsTreeDataProvider
     )
   );
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -352,7 +352,12 @@ export async function activate(context: vscode.ExtensionContext) {
     context,
     "neo3-visual-devtracker.tracker.openWallet",
     (commandArguments) =>
-      TrackerCommands.openWallet(context, autoComplete, commandArguments)
+      TrackerCommands.openWallet(
+        context,
+        autoComplete,
+        commandArguments,
+        activeConnection
+      )
   );
 }
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -347,6 +347,13 @@ export async function activate(context: vscode.ExtensionContext) {
     (commandArguments) =>
       TrackerCommands.openContract(context, autoComplete, commandArguments)
   );
+
+  registerCommand(
+    context,
+    "neo3-visual-devtracker.tracker.openWallet",
+    (commandArguments) =>
+      TrackerCommands.openWallet(context, autoComplete, commandArguments)
+  );
 }
 
 export function deactivate() {

--- a/src/extension/neoExpress/neoExpressInstanceManager.ts
+++ b/src/extension/neoExpress/neoExpressInstanceManager.ts
@@ -3,7 +3,7 @@ import * as vscode from "vscode";
 import ActiveConnection from "../activeConnection";
 import BlockchainIdentifier from "../blockchainIdentifier";
 import BlockchainsTreeDataProvider from "../vscodeProviders/blockchainsTreeDataProvider";
-import { CommandArguments } from "../commandArguments";
+import { CommandArguments } from "../commands/commandArguments";
 import Log from "../../shared/log";
 import NeoExpress from "./neoExpress";
 import IoHelpers from "../util/ioHelpers";

--- a/src/extension/panelControllers/contractPanelController.ts
+++ b/src/extension/panelControllers/contractPanelController.ts
@@ -29,7 +29,7 @@ export default class ContractPanelController extends PanelControllerBase<
     );
     autoComplete.onChange((autoCompleteData) => {
       const name = autoCompleteData.contractNames[contractHash] || contractHash;
-      this.updateViewState({ panelTitle: name, ...autoCompleteData });
+      this.updateViewState({ panelTitle: name, autoCompleteData });
     });
   }
 

--- a/src/extension/panelControllers/walletPanelController.ts
+++ b/src/extension/panelControllers/walletPanelController.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 
+import ActiveConnection from "../activeConnection";
 import AutoComplete from "../autoComplete";
 import Log from "../../shared/log";
 import PanelControllerBase from "./panelControllerBase";
@@ -15,7 +16,8 @@ export default class WalletPanelController extends PanelControllerBase<
   constructor(
     context: vscode.ExtensionContext,
     private readonly address: string,
-    autoComplete: AutoComplete
+    autoComplete: AutoComplete,
+    private readonly activeConnection: ActiveConnection
   ) {
     super(
       {
@@ -23,6 +25,8 @@ export default class WalletPanelController extends PanelControllerBase<
         panelTitle: autoComplete.data.addressNames[address][0] || address,
         autoCompleteData: autoComplete.data,
         address,
+        addressInfo: null,
+        offline: false,
       },
       context
     );
@@ -30,17 +34,38 @@ export default class WalletPanelController extends PanelControllerBase<
       const name = autoComplete.data.addressNames[address][0] || address;
       this.updateViewState({ panelTitle: name, autoCompleteData });
     });
+    activeConnection.onChange(() => this.updateBalances());
+    this.updateBalances();
   }
 
   onClose() {}
 
   protected async onRequest(request: WalletViewRequest) {
     Log.log(LOG_PREFIX, `Request: ${JSON.stringify(request)}`);
+
     if (request.copyAddress) {
       await vscode.env.clipboard.writeText(this.address);
       vscode.window.showInformationMessage(
         `Wallet address copied to clipboard: ${this.address}`
       );
+    }
+
+    if (request.refresh) {
+      await this.updateBalances();
+    }
+  }
+
+  private async updateBalances() {
+    const blockchainMonitor = this.activeConnection.connection
+      ?.blockchainMonitor;
+    if (blockchainMonitor) {
+      const addressInfo = await blockchainMonitor.getAddress(
+        this.address,
+        true
+      );
+      await this.updateViewState({ addressInfo, offline: false });
+    } else {
+      await this.updateViewState({ addressInfo: null, offline: true });
     }
   }
 }

--- a/src/extension/panelControllers/walletPanelController.ts
+++ b/src/extension/panelControllers/walletPanelController.ts
@@ -1,0 +1,46 @@
+import * as vscode from "vscode";
+
+import AutoComplete from "../autoComplete";
+import Log from "../../shared/log";
+import PanelControllerBase from "./panelControllerBase";
+import WalletViewRequest from "../../shared/messages/walletViewRequest";
+import WalletViewState from "../../shared/viewState/walletViewState";
+
+const LOG_PREFIX = "WalletPanelController";
+
+export default class WalletPanelController extends PanelControllerBase<
+  WalletViewState,
+  WalletViewRequest
+> {
+  constructor(
+    context: vscode.ExtensionContext,
+    private readonly address: string,
+    autoComplete: AutoComplete
+  ) {
+    super(
+      {
+        view: "wallet",
+        panelTitle: autoComplete.data.addressNames[address][0] || address,
+        autoCompleteData: autoComplete.data,
+        address,
+      },
+      context
+    );
+    autoComplete.onChange((autoCompleteData) => {
+      const name = autoComplete.data.addressNames[address][0] || address;
+      this.updateViewState({ panelTitle: name, autoCompleteData });
+    });
+  }
+
+  onClose() {}
+
+  protected async onRequest(request: WalletViewRequest) {
+    Log.log(LOG_PREFIX, `Request: ${JSON.stringify(request)}`);
+    if (request.copyAddress) {
+      await vscode.env.clipboard.writeText(this.address);
+      vscode.window.showInformationMessage(
+        `Wallet address copied to clipboard: ${this.address}`
+      );
+    }
+  }
+}

--- a/src/extension/vscodeProviders/walletsTreeDataProvider.ts
+++ b/src/extension/vscodeProviders/walletsTreeDataProvider.ts
@@ -1,0 +1,87 @@
+import * as vscode from "vscode";
+
+import ActiveConnection from "../activeConnection";
+import Log from "../../shared/log";
+import posixPath from "../util/posixPath";
+import WalletDetector from "../fileDetectors/walletDetector";
+
+const LOG_PREFIX = "WalletsTreeDataProvider";
+
+type WalletData = {
+  address: string;
+  name: string;
+  path: string;
+  isNeoExpress: boolean;
+};
+
+export default class WalletsTreeDataProvider
+  implements vscode.TreeDataProvider<WalletData> {
+  onDidChangeTreeData: vscode.Event<void>;
+
+  private readonly onDidChangeTreeDataEmitter: vscode.EventEmitter<void>;
+
+  private wallets: WalletData[] = [];
+
+  constructor(
+    private readonly extensionPath: string,
+    private readonly activeConnection: ActiveConnection,
+    private readonly walletDetector: WalletDetector
+  ) {
+    this.onDidChangeTreeDataEmitter = new vscode.EventEmitter<void>();
+    this.onDidChangeTreeData = this.onDidChangeTreeDataEmitter.event;
+    activeConnection.onChange(() => this.refresh());
+    walletDetector.onChange(() => this.refresh());
+  }
+
+  getTreeItem(wallet: WalletData): vscode.TreeItem {
+    return {
+      command: {
+        command: "neo3-visual-devtracker.tracker.openWallet",
+        arguments: [{ address: wallet.address }],
+        title: wallet.address,
+      },
+      description: wallet.address,
+      label: wallet.name,
+      tooltip: `${wallet.address}\n${wallet.path}`,
+      iconPath: wallet.isNeoExpress
+        ? posixPath(this.extensionPath, "resources", "blockchain-express.svg")
+        : posixPath(this.extensionPath, "resources", "blockchain-private.svg"),
+    };
+  }
+
+  getChildren(wallet?: WalletData): WalletData[] {
+    return wallet ? [] : this.wallets;
+  }
+
+  async refresh() {
+    Log.log(LOG_PREFIX, "Refreshing wallet list");
+    const newData: WalletData[] = [];
+    for (const nep6Wallet of this.walletDetector.wallets) {
+      for (const account of nep6Wallet.accounts) {
+        newData.push({
+          address: account.address,
+          name: account.label,
+          path: nep6Wallet.path,
+          isNeoExpress: false,
+        });
+      }
+    }
+    const blockchainIdentifier = this.activeConnection.connection
+      ?.blockchainIdentifier;
+    const expressWallets = await blockchainIdentifier?.getWalletAddresses();
+    if (expressWallets) {
+      for (const name of Object.keys(expressWallets)) {
+        const address = expressWallets[name];
+        newData.push({
+          address,
+          name,
+          path: blockchainIdentifier?.configPath || "",
+          isNeoExpress: true,
+        });
+      }
+    }
+    newData.sort((a, b) => a.name.localeCompare(b.name));
+    this.wallets = newData;
+    this.onDidChangeTreeDataEmitter.fire();
+  }
+}

--- a/src/panel/components/tracker/AddressDetails.tsx
+++ b/src/panel/components/tracker/AddressDetails.tsx
@@ -40,33 +40,37 @@ export default function AddressDetails({
       <p style={{ fontWeight: "bold", fontSize: "1.25rem", marginTop: 0 }}>
         {(addressInfo.gasBalance / 100000000.0).toLocaleString()} GAS
       </p>
-      <p style={{ marginBottom: 5 }}>
-        <small>All NEP 17 balances:</small>
-      </p>
-      <p style={{ marginTop: 0 }}>
-        <table style={{ width: "100%" }}>
-          <tbody>
-            {Object.keys(addressInfo.allBalances).map((assetHash) => {
-              const balance = addressInfo.allBalances[assetHash];
-              return (
-                <tr key={assetHash}>
-                  <td>
-                    <small>
-                      <ScriptToken
-                        token={reverseBytes(assetHash.substring(2))}
-                        autoCompleteData={autoCompleteData}
-                      />
-                    </small>
-                  </td>
-                  <th>
-                    <small>{balance.toLocaleString()}</small>
-                  </th>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </p>
+      {!!Object.keys(addressInfo.allBalances).length && (
+        <>
+          <p style={{ marginBottom: 5 }}>
+            <small>All NEP 17 balances:</small>
+          </p>
+          <p style={{ marginTop: 0 }}>
+            <table style={{ width: "100%" }}>
+              <tbody>
+                {Object.keys(addressInfo.allBalances).map((assetHash) => {
+                  const balance = addressInfo.allBalances[assetHash];
+                  return (
+                    <tr key={assetHash}>
+                      <td>
+                        <small>
+                          <ScriptToken
+                            token={reverseBytes(assetHash.substring(2))}
+                            autoCompleteData={autoCompleteData}
+                          />
+                        </small>
+                      </td>
+                      <th>
+                        <small>{balance.toLocaleString()}</small>
+                      </th>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </p>
+        </>
+      )}
     </div>
   );
 }

--- a/src/panel/components/views/Wallet.tsx
+++ b/src/panel/components/views/Wallet.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 
+import AddressDetails from "../tracker/AddressDetails";
+import Hash from "../Hash";
+import NavButton from "../NavButton";
 import WalletViewState from "../../../shared/viewState/walletViewState";
 import WalletViewRequest from "../../../shared/messages/walletViewRequest";
-import Hash from "../Hash";
 
 type Props = {
   viewState: WalletViewState;
@@ -30,6 +32,44 @@ export default function Wallet({ viewState, postMessage }: Props) {
           </strong>{" "}
           <em> &mdash; click to copy address to clipboard</em>
         </div>
+      </p>
+      <p style={{ paddingLeft: 20 }}>
+        <div style={{ fontWeight: "bold", marginBottom: 10, marginTop: 15 }}>
+          Balance information:
+        </div>
+        {!!viewState.addressInfo && (
+          <div
+            style={{
+              backgroundColor: "var(--vscode-editor-background)",
+              color: "var(--vscode-editor-foreground)",
+              border: "1px solid var(--vscode-focusBorder)",
+              boxShadow: "-1px 1px 2px 0px var(--vscode-focusBorder)",
+              borderRadius: 10,
+              padding: 20,
+              margin: 50,
+              marginTop: 20,
+              overflow: "auto",
+            }}
+          >
+            <AddressDetails
+              addressInfo={viewState.addressInfo}
+              autoCompleteData={viewState.autoCompleteData}
+            />
+          </div>
+        )}
+        {!viewState.addressInfo && !viewState.offline && (
+          <div style={{ paddingLeft: 20 }}>Loading balances&hellip;</div>
+        )}
+        {!viewState.addressInfo && viewState.offline && (
+          <div style={{ paddingLeft: 20 }}>
+            <em>(Connect to a blockchain to retrieve balances.)</em>
+          </div>
+        )}
+      </p>
+      <p style={{ paddingLeft: 20, textAlign: "center" }}>
+        <NavButton onClick={() => postMessage({ refresh: true })}>
+          Refresh
+        </NavButton>
       </p>
     </div>
   );

--- a/src/panel/components/views/Wallet.tsx
+++ b/src/panel/components/views/Wallet.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+import WalletViewState from "../../../shared/viewState/walletViewState";
+import WalletViewRequest from "../../../shared/messages/walletViewRequest";
+import Hash from "../Hash";
+
+type Props = {
+  viewState: WalletViewState;
+  postMessage: (message: WalletViewRequest) => void;
+};
+
+export default function Wallet({ viewState, postMessage }: Props) {
+  const address = viewState.address;
+  const name =
+    viewState.autoCompleteData.addressNames[address].join(", ") ||
+    "Unknown wallet";
+  return (
+    <div style={{ padding: 10 }}>
+      <h1>{name}</h1>
+      <p style={{ paddingLeft: 20 }}>
+        <div style={{ fontWeight: "bold", marginBottom: 10, marginTop: 15 }}>
+          Address:
+        </div>
+        <div
+          style={{ cursor: "pointer", paddingLeft: 20 }}
+          onClick={() => postMessage({ copyAddress: true })}
+        >
+          <strong>
+            <Hash hash={address} />
+          </strong>{" "}
+          <em> &mdash; click to copy address to clipboard</em>
+        </div>
+      </p>
+    </div>
+  );
+}

--- a/src/panel/viewRouter.tsx
+++ b/src/panel/viewRouter.tsx
@@ -16,6 +16,8 @@ import TrackerViewState from "../shared/viewState/trackerViewState";
 import View from "../shared/view";
 import ViewRequest from "../shared/messages/viewRequest";
 import ViewStateBase from "../shared/viewState/viewStateBase";
+import Wallet from "./components/views/Wallet";
+import WalletViewState from "../shared/viewState/walletViewState";
 
 declare var acquireVsCodeApi: any;
 const vscode = acquireVsCodeApi();
@@ -90,6 +92,14 @@ export default function ViewRouter() {
         panelContent = (
           <Tracker
             viewState={viewState as TrackerViewState}
+            postMessage={(typedRequest) => postMessage({ typedRequest })}
+          />
+        );
+        break;
+      case "wallet":
+        panelContent = (
+          <Wallet
+            viewState={viewState as WalletViewState}
             postMessage={(typedRequest) => postMessage({ typedRequest })}
           />
         );

--- a/src/shared/messages/walletViewRequest.ts
+++ b/src/shared/messages/walletViewRequest.ts
@@ -1,0 +1,3 @@
+type WalletViewRequest = { copyAddress?: boolean };
+
+export default WalletViewRequest;

--- a/src/shared/messages/walletViewRequest.ts
+++ b/src/shared/messages/walletViewRequest.ts
@@ -1,3 +1,3 @@
-type WalletViewRequest = { copyAddress?: boolean };
+type WalletViewRequest = { copyAddress?: boolean; refresh?: boolean };
 
 export default WalletViewRequest;

--- a/src/shared/view.ts
+++ b/src/shared/view.ts
@@ -3,6 +3,7 @@ type View =
   | "invokeFile"
   | "quickStart"
   | "storageExplorer"
-  | "tracker";
+  | "tracker"
+  | "wallet";
 
 export default View;

--- a/src/shared/viewState/walletViewState.ts
+++ b/src/shared/viewState/walletViewState.ts
@@ -1,3 +1,4 @@
+import AddressInfo from "../addressInfo";
 import AutoCompleteData from "../autoCompleteData";
 
 type WalletViewState = {
@@ -5,6 +6,8 @@ type WalletViewState = {
   panelTitle: string;
   autoCompleteData: AutoCompleteData;
   address: string;
+  addressInfo: AddressInfo | null;
+  offline: boolean;
 };
 
 export default WalletViewState;

--- a/src/shared/viewState/walletViewState.ts
+++ b/src/shared/viewState/walletViewState.ts
@@ -1,0 +1,10 @@
+import AutoCompleteData from "../autoCompleteData";
+
+type WalletViewState = {
+  view: "wallet";
+  panelTitle: string;
+  autoCompleteData: AutoCompleteData;
+  address: string;
+};
+
+export default WalletViewState;


### PR DESCRIPTION
This adds a new panel which lists all currently known wallets (Neo Express or NEP-6). You can click on any wallet to show its balances (and see a copiable address).

This meets the requirements of #38, so Closes #38 but I am open to seeing new issues with suggestions for other functionality that can be provided in the new views.