### PR TITLE
Create new Neo Express instance should default to "default.neo-expres…

### DIFF
--- a/src/extension/commands/neoExpressCommands.ts
+++ b/src/extension/commands/neoExpressCommands.ts
@@ -82,11 +82,15 @@ export default class NeoExpressCommands {
     if (!nodeCount) {
       return;
     }
+    const worksapcePath = (vscode.workspace.workspaceFolders || [])[0]?.uri
+      .fsPath;
     const configSavePath = await IoHelpers.pickSaveFile(
       "Create",
       "Neo Express Configurations",
       "neo-express",
-      (vscode.workspace.workspaceFolders || [])[0]?.uri
+      worksapcePath
+        ? vscode.Uri.file(posixPath(worksapcePath, "default.neo-express"))
+        : undefined
     );
     if (!configSavePath) {
       return;


### PR DESCRIPTION
…s" as a file name fixes #98