### PR TITLE
update RPC node list for RC4 TestNet

### DIFF
--- a/src/extension/fileDetectors/serverListDetector.ts
+++ b/src/extension/fileDetectors/serverListDetector.ts
@@ -32,7 +32,7 @@ const UNKNOWN_BLOCKCHAIN =
 const WELL_KNOWN_BLOCKCHAINS: { [genesisHash: string]: string } = {
   "0x1f4d1defa46faa5e7b9b8d3f79a06bec777d7c26c4aa5f6f5899a291daa87c15":
     "Neo N3 MainNet",
-  "0x614a807a3e545df0cb5c96d4d387e620e3e34d441f849b9a4033e0b4f906805d":
+  "0x9d3276785e7306daf59a3f3b9e31912c095598bbfb8a4476b821b0e59be4c57a":
     "Neo N3 TestNet",
 };
 
@@ -49,11 +49,11 @@ const SEED_URLS: { [url: string]: boolean } = {
   "http://seed4.neo.org:10332": true,
   "http://seed5.neo.org:10332": true,
   // V3 TestNet:
-  "http://seed1t.neo.org:20332": true,
-  "http://seed2t.neo.org:20332": true,
-  "http://seed3t.neo.org:20332": true,
-  "http://seed4t.neo.org:20332": true,
-  "http://seed5t.neo.org:20332": true,
+  "http://seed1t4.neo.org:20332": true,
+  "http://seed2t4.neo.org:20332": true,
+  "http://seed3t4.neo.org:20332": true,
+  "http://seed4t4.neo.org:20332": true,
+  "http://seed5t4.neo.org:20332": true,
 };
 
 export default class ServerListDetector extends DetectorBase {


### PR DESCRIPTION
The DevTracker is still using the RC3 TestNet nodes, which seem to be decommissioned now. This changes the node URLs and genesis hash for RC3 to the RC4 versions.