### PR TITLE
Added a <Delete Me> button to the Contract views

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,15 @@
 
   // Auto format files on save using Prettier:
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+
+  //Adding the following code allows us to change the colors on the status bar at the bottom of the VS Code border to whatever we like
+  "workbench.colorCustomizations": {
+    "statusBar.background": "#1A1A1A",
+    "statusBar.noFolderBackground": "#212121",
+    "statusBar.debuggingBackground": "#263238",
+    "statusBarItem.prominentForeground": "#55eb34",
+
+    "statusBar.foreground": "#ce8416"
+  }
 }

--- a/src/panel/components/views/Contract.tsx
+++ b/src/panel/components/views/Contract.tsx
@@ -24,11 +24,20 @@ export default function Contract({ viewState, postMessage }: Props) {
     viewState.autoCompleteData.contractPaths[name] ||
     [];
 
+  let statement;
+
+  if (name === "StdLib") {
+    statement = "Note- these contracts do not contain any storage";
+  } else {
+    statement = "";
+  }
+
   return (
     <div style={{ padding: 10 }}>
       <h1>{name}</h1>
       <button> Click to Delete </button>
-
+      <br></br>
+      <h2> {statement} </h2>
       {!!description && (
         <p style={{ paddingLeft: 20 }}>
           <div style={{ fontWeight: "bold", marginBottom: 10, marginTop: 15 }}>

--- a/src/panel/components/views/Contract.tsx
+++ b/src/panel/components/views/Contract.tsx
@@ -23,9 +23,12 @@ export default function Contract({ viewState, postMessage }: Props) {
     viewState.autoCompleteData.contractPaths[hash] ||
     viewState.autoCompleteData.contractPaths[name] ||
     [];
+
   return (
     <div style={{ padding: 10 }}>
       <h1>{name}</h1>
+      <button> Click to Delete </button>
+
       {!!description && (
         <p style={{ paddingLeft: 20 }}>
           <div style={{ fontWeight: "bold", marginBottom: 10, marginTop: 15 }}>


### PR DESCRIPTION
In line with issue #133, added a <Delete Me> button that can be used to delete contracts (or even chains) that are unused. Note that the button currently isn't functional. I can perhaps add an inline icon later if need be.

Note, however, it is not yet functional. I would someone's help to write the method to destroy contracts as that is a bit beyond the scope of what I am capable of at this point (unless it entails copying and pasting what is available on the NEO docs website).

Other buttons/functionality that could consider adding to the sidebar would include a smart contract explorer, a governance enabler (voting, candidate registration), wallet functions, data science functions, fees querying, oracle querying, etc.

(Note that the other part of this pull request includes adding a close bracket that was missing from the first pull request I sent earlier).