### PR TITLE
Include an option to pass data on deploy contract

### DIFF
--- a/src/extension/commands/neoExpressCommands.ts
+++ b/src/extension/commands/neoExpressCommands.ts
@@ -54,11 +54,19 @@ export default class NeoExpressCommands {
     if (!contractFile) {
       return;
     }
+    const contractData = await IoHelpers.enterString(
+      "Enter optional data to deploy the contract"
+    );
+    let data: string[] = [];
+    if (contractData) {
+      data = ['-d', contractData];
+    }
     const output = await neoExpress.run(
       "contract",
       "deploy",
       contractFile,
       account,
+      ...data,
       "-i",
       identifier.configPath
     );


### PR DESCRIPTION
We cannot deploy a contract that needs optional data to be passed to `_deploy` using the devtracker. Included a text field for this.

![image](https://github.com/N3developertoolkit/neo3-visual-tracker/assets/19419485/e52afa83-94c5-4479-8403-27a135a54202)
![image](https://github.com/N3developertoolkit/neo3-visual-tracker/assets/19419485/7bfa1307-c083-4889-980d-f33b3b51eb7d)
![image](https://github.com/N3developertoolkit/neo3-visual-tracker/assets/19419485/d83a527c-d1e7-4f83-90a4-6da7902ba497)
