### PR TITLE
Show methods of native contracts and already deployed contracts

### DIFF
--- a/src/extension/neoExpress/neoExpressIo.ts
+++ b/src/extension/neoExpress/neoExpressIo.ts
@@ -27,7 +27,7 @@ export default class NeoExpressIo {
       return null;
     }
     try {
-      return JSONC.parse(output.message) as neonSc.ContractManifestJson;
+      return JSONC.parse(output.message)[0] as neonSc.ContractManifestJson;
     } catch (e) {
       throw Error(`Get contract error: ${e.message}`);
     }


### PR DESCRIPTION
The native contracts methods weren't shown in the invocation screen because the neo-express result parsing was incorrect

currently:
![image](https://github.com/N3developertoolkit/neo3-visual-tracker/assets/19419485/992d8f4a-522e-4940-b5ee-bc7118b51a10)

with the fix:
![image](https://github.com/N3developertoolkit/neo3-visual-tracker/assets/19419485/7594f029-41b9-468f-a1c3-1fad04afc020)
