### PR TITLE
Fix DevTracker showing empty view on search

### DIFF
--- a/src/extension/panelControllers/trackerPanelController.ts
+++ b/src/extension/panelControllers/trackerPanelController.ts
@@ -266,22 +266,28 @@ export default class TrackerPanelController extends PanelControllerBase<
       return;
     }
 
+    var success = false;
     try {
       const block = await this.blockchainMonitor.getBlock(query, false);
       if (block) {
         request.selectBlock = block.hash;
+        success = true;
       }
     } catch {
       try {
         const tx = await this.getTransaction(query.toLowerCase(), false);
         if (tx) {
           request.selectTransaction = tx.tx.hash;
+          success = true;
         }
       } catch {
-        vscode.window.showErrorMessage(
-          `Could not retrieve block or transaction with hash ${query}`
-        );
+        success = false;
       }
+    }
+    if (!success) {
+      vscode.window.showErrorMessage(
+        `Could not retrieve block or transaction with hash ${query}`
+      );
     }
   }
 }

--- a/src/panel/components/tracker/Search.tsx
+++ b/src/panel/components/tracker/Search.tsx
@@ -35,7 +35,8 @@ export default function Search({ searchHistory, onSearch }: Props) {
   return (
     <form
       style={formStyle}
-      onSubmit={() => {
+      onSubmit={(e) => {
+        e.preventDefault();
         onSearch(searchInput);
         setSearchInput("");
       }}


### PR DESCRIPTION
Searching anything on devtracker blockchain view showed an empty view, either with a valid or an invalid search. It works with the search history buttons, but not for the text input.
And for invalid searches, there was no error dialog showing that the search had invalid results, making it hard to know what happened.

valid search:
![image](https://github.com/N3developertoolkit/neo3-visual-tracker/assets/19419485/49763b50-3954-43c0-8e75-3e3f949dd0ac)
previous output:
![image](https://github.com/N3developertoolkit/neo3-visual-tracker/assets/19419485/df811b97-4b23-4059-a589-cbd78b461796)
current output (doesn't show empty view anymore):
![image](https://github.com/N3developertoolkit/neo3-visual-tracker/assets/19419485/bf4bc522-5b34-41f6-931b-70a32033a249)

invalid search:
![image](https://github.com/N3developertoolkit/neo3-visual-tracker/assets/19419485/ecc17799-758e-47d0-80ef-212c6e565157)
![image](https://github.com/N3developertoolkit/neo3-visual-tracker/assets/19419485/506c4ac2-a60b-4f25-9c8c-ceb3836cf8e6)
